### PR TITLE
Update the grc function to allow for weights

### DIFF
--- a/pyrocs/complex_systems/grc.py
+++ b/pyrocs/complex_systems/grc.py
@@ -2,7 +2,7 @@ import networkx as nx
 import numpy as np
 
 
-def grc(A : np.ndarray, directed : bool):
+def grc(A : np.ndarray, directed : bool, use_weights=False):
     """
     Global reaching centrality (GRC) measures the level of hierarchy within a network based on flow. 
     The equation within the package follows the formulations from 
@@ -26,9 +26,16 @@ def grc(A : np.ndarray, directed : bool):
         A: Square matrix of adjacencies in the network
         directed (bool): If true, assume A represents a directed graph (row -> column).
             If false, assume A represents an undirected graph.
+        use_weights (bool): If true, the nonzero values of A are
+        used as edge weights for the computation of grc.
     Returns:
         Global reaching centrality of the graph 
     """
+    if use_weights:
+        # by default, from_numpy_array assigns the nonzero values of A to the edges under the key "weight"
+        weight = "weight"
+    else:
+        weight = None
 
     if directed:
         G = nx.from_numpy_array(A, nx.DiGraph)
@@ -39,4 +46,4 @@ def grc(A : np.ndarray, directed : bool):
         print("WARNING: Social network to compute GRC over has no edges!")
         return 0.0
     else:
-        return nx.global_reaching_centrality(G)
+        return nx.global_reaching_centrality(G, weight=weight)

--- a/test/test_complex_systems.py
+++ b/test/test_complex_systems.py
@@ -58,6 +58,12 @@ def test_grc_undirected():
     A = np.array([[0, 1, 0], [1, 0, 1], [0, 1, 0]])
     result = grc(A, directed=False)
     assert result > 0
+    
+def test_grc_weights():
+    # Test undirected graph with edges
+    A = np.array([[0, 2, 0], [1, 0, 2], [0, 1, 0]])
+    result = grc(A, directed=False, use_weights=True)
+    assert result > 0
 
 def test_grc_directed():
     # Test directed graph with edges


### PR DESCRIPTION
## Description
This PR adds the ability to use the nonzero values of the matrix passed to `grc()` as weights for the computation of grc. A new keyword argument is added called `use_weights` and defaults to False, which maintains the default behavior of the function.

## Motivation and Context
This expands the `grc()` function's capabilities by allowing for the use of weighted edges.

## How has this been tested?
A test is added to `test_complex_systems.py` under the name `test_grc_weights`.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

<!--- Template Acknowledgements: -->
<!--- Template grabbed from https://github.com/stevemao/github-issue-templates/blob/master/questions-answers/PULL_REQUEST_TEMPLATE.md -->